### PR TITLE
Pre-release changes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,7 @@ const config = {
     'plugin:@typescript-eslint/recommended-type-checked',
   ],
   plugins: ['@typescript-eslint'],
-  ignorePatterns: ['.eslintrc.cjs', 'example'],
+  ignorePatterns: ['.eslintrc.cjs', 'example', 'dist'],
   parserOptions: {
     project: true,
     tsconfigRootDir: __dirname,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,12 @@
         "@babel/core": "^7.24.0",
         "@babel/preset-env": "^7.24.0",
         "@babel/preset-typescript": "^7.23.3",
-        "@happy-dom/jest-environment": "^13.10.1",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.29",
         "@typescript-eslint/eslint-plugin": "^7.3.0",
         "@typescript-eslint/parser": "^7.3.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-transform-import-meta": "^2.2.1",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -2285,23 +2283,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@happy-dom/jest-environment": {
-      "version": "13.10.1",
-      "resolved": "https://registry.npmjs.org/@happy-dom/jest-environment/-/jest-environment-13.10.1.tgz",
-      "integrity": "sha512-g6DY+qLAbeyDQIqPncnBcZVwZqZbYhR33t42vrWyjWHv2lAYudp6TLYvwDWSNG9f8GQLmEZ9VMxVBnVtEsy2SQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^29.4.0",
-        "@jest/fake-timers": "^29.4.0",
-        "@jest/types": "^29.4.0",
-        "happy-dom": "^13.10.1",
-        "jest-mock": "^29.4.0",
-        "jest-util": "^29.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -4177,19 +4158,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/babel-plugin-transform-import-meta": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.2.1.tgz",
-      "integrity": "sha512-AxNh27Pcg8Kt112RGa3Vod2QS2YXKKJ6+nSvRtv7qQTJAdx0MZa4UHZ4lnxHUWA2MNbLuZQv5FVab4P1CoLOWw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.4.4",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.10.0"
-      }
-    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -5561,20 +5529,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/happy-dom": {
-      "version": "13.10.1",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-13.10.1.tgz",
-      "integrity": "sha512-9GZLEFvQL5EgfJX2zcBgu1nsPUn98JF/EiJnSfQbdxI6YEQGqpd09lXXxOmYonRBIEFz9JlGCOiPflDzgS1p8w==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "description": "Piwik PRO basic tracking library for the frontend.",
   "version": "1.0.0",
   "type": "module",
-  "main": "dist/index.umd.js",
+  "main": "dist/index.umd.cjs",
   "module": "dist/index.js",
-  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -21,7 +21,6 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.d.ts",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -37,14 +36,12 @@
     "@babel/core": "^7.24.0",
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-typescript": "^7.23.3",
-    "@happy-dom/jest-environment": "^13.10.1",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.29",
     "@typescript-eslint/eslint-plugin": "^7.3.0",
     "@typescript-eslint/parser": "^7.3.0",
     "babel-jest": "^29.7.0",
-    "babel-plugin-transform-import-meta": "^2.2.1",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/src/core/index.test.ts
+++ b/src/core/index.test.ts
@@ -14,9 +14,15 @@ describe('init', () => {
     ) as HTMLScriptElement
 
     expect(script.async).toBe(true)
-    expect(script.text).toMatch(
-      /window\[dataLayerName\]=window\[dataLayerName\]||\[\]/
-    )
+    expect(script.text)
+      .toContain(`(function(window, document, dataLayerName, id) {
+  window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
+  function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString();f="; SameSite=Strict"}document.cookie=a+"="+b+d+f+"; path=/"}
+  var isStgDebug=(window.location.href.match("stg_debug")||document.cookie.match("stg_debug"))&&!window.location.href.match("stg_disable_debug");stgCreateCookie("stg_debug",isStgDebug?1:"",isStgDebug?14:-1);
+  var qP=[];dataLayerName!=="dataLayer"&&qP.push("data_layer_name="+dataLayerName),isStgDebug&&qP.push("stg_debug");var qPString=qP.length>0?("?"+qP.join("&")):"";
+  tags.async=!0,tags.src="containerUrl"+id+".js"+qPString,scripts.parentNode.insertBefore(tags,scripts);
+  !function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
+  })(window, document, 'dataLayer', 'containerId');`)
   })
 
   it('should set nonce attribute if provided', () => {
@@ -34,9 +40,14 @@ describe('init', () => {
 
     init('', 'containerUrl')
 
+    const script = document.getElementById(
+      'PiwikPROInitializer'
+    ) as HTMLScriptElement
+
     expect(consoleErrorMock).toHaveBeenCalledWith(
       'Empty tracking code for Piwik Pro.'
     )
+    expect(script).toBeNull()
   })
 
   it('should log error if containerUrl is empty', () => {
@@ -44,9 +55,14 @@ describe('init', () => {
 
     init('containerId', '')
 
+    const script = document.getElementById(
+      'PiwikPROInitializer'
+    ) as HTMLScriptElement
+
     expect(consoleErrorMock).toHaveBeenCalledWith(
       'Empty tracking URL for Piwik Pro.'
     )
+    expect(script).toBeNull()
   })
 
   it('should log error if trying to run in server environment', () => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,17 +27,27 @@ export function init(
   if (nonce) {
     scriptEl.nonce = nonce
   }
-  scriptEl.text = `(function(window, document, dataLayerName, id) {
-window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
-function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString();f="; SameSite=Strict"}document.cookie=a+"="+b+d+f+"; path=/"}
-var isStgDebug=(window.location.href.match("stg_debug")||document.cookie.match("stg_debug"))&&!window.location.href.match("stg_disable_debug");stgCreateCookie("stg_debug",isStgDebug?1:"",isStgDebug?14:-1);
-var qP=[];dataLayerName!=="dataLayer"&&qP.push("data_layer_name="+dataLayerName),isStgDebug&&qP.push("stg_debug");var qPString=qP.length>0?("?"+qP.join("&")):"";
-tags.async=!0,tags.src="${containerUrl}/"+id+".js"+qPString,scripts.parentNode.insertBefore(tags,scripts);
-!function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
-})(window, document, 'dataLayer', '${containerId}')`
+  scriptEl.text = getInitScript({ containerId, containerUrl })
 
   const body: HTMLHeadElement = document.getElementsByTagName('body')[0]
   body.appendChild(scriptEl)
+}
+
+export function getInitScript({
+  containerId,
+  containerUrl,
+}: {
+  containerId: string
+  containerUrl: string
+}) {
+  return `(function(window, document, dataLayerName, id) {
+  window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
+  function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString();f="; SameSite=Strict"}document.cookie=a+"="+b+d+f+"; path=/"}
+  var isStgDebug=(window.location.href.match("stg_debug")||document.cookie.match("stg_debug"))&&!window.location.href.match("stg_disable_debug");stgCreateCookie("stg_debug",isStgDebug?1:"",isStgDebug?14:-1);
+  var qP=[];dataLayerName!=="dataLayer"&&qP.push("data_layer_name="+dataLayerName),isStgDebug&&qP.push("stg_debug");var qPString=qP.length>0?("?"+qP.join("&")):"";
+  tags.async=!0,tags.src="${containerUrl}"+id+".js"+qPString,scripts.parentNode.insertBefore(tags,scripts);
+  !function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
+  })(window, document, 'dataLayer', '${containerId}');`
 }
 
 export const IS_DEBUG =

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@ export * from './interfaces/product'
 
 export default {
   initialize: PiwikPro.init,
+  getInitScript: PiwikPro.getInitScript,
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     }),
   ],
   build: {
+    sourcemap: true,
+    minify: false,
     lib: {
       entry: './src/index.ts',
       name: 'tracking-base-library',


### PR DESCRIPTION
- add `getInitialScript` - so we can have one source of truth for frameworks with alternative ways to load scripts like nextjs
- remove unused dependencies
- tests - make sure script element is not created if invalid configuration is provided
- emit sourcemaps on build