### PR TITLE
PPI-1101 Setup CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,0 +1,34 @@
+name: Lint and Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  run-tests:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ PiwikPro.initialize('container-id', 'container-url');
 
 ### Setup with nonce
 
-The nonce attribute is useful to allow-list specific elements, such as a particular inline script or style elements. It can help you to avoid using the CSP unsafe-inline directive, which would allow-l
-ist all inline scripts or styles.
+The nonce attribute is useful to allow-list specific elements, such as a particular inline script or style elements. It can help you to avoid using the CSP unsafe-inline directive, which would allow-list all inline scripts or styles.
 
 If you want your nonce to be passed to the script, pass it as the third argument when calling the script initialization method.
 
@@ -40,6 +39,15 @@ If you want your nonce to be passed to the script, pass it as the third argument
 import PiwikPro from '@piwikpro/tracking-base-library';
 
 PiwikPro.initialize('container-id', 'container-url', 'nonce-string');
+```
+
+### Basic usage
+```ts
+import { PageViews, GoalConversions } from "@piwikpro/tracking-base-library"
+
+PageViews.trackPageView();
+
+GoalConversions.trackGoal(1, 100);
 ```
 
 

--- a/docs/README_BASE.md
+++ b/docs/README_BASE.md
@@ -27,8 +27,7 @@ PiwikPro.initialize('container-id', 'container-url');
 
 ### Setup with nonce
 
-The nonce attribute is useful to allow-list specific elements, such as a particular inline script or style elements. It can help you to avoid using the CSP unsafe-inline directive, which would allow-l
-ist all inline scripts or styles.
+The nonce attribute is useful to allow-list specific elements, such as a particular inline script or style elements. It can help you to avoid using the CSP unsafe-inline directive, which would allow-list all inline scripts or styles.
 
 If you want your nonce to be passed to the script, pass it as the third argument when calling the script initialization method.
 
@@ -36,4 +35,13 @@ If you want your nonce to be passed to the script, pass it as the third argument
 import PiwikPro from '@piwikpro/tracking-base-library';
 
 PiwikPro.initialize('container-id', 'container-url', 'nonce-string');
+```
+
+### Basic usage
+```ts
+import { PageViews, GoalConversions } from "@piwikpro/tracking-base-library"
+
+PageViews.trackPageView();
+
+GoalConversions.trackGoal(1, 100);
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@piwik-pro/tracking-base-library",
+  "name": "@piwikpro/tracking-base-library",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@piwik-pro/tracking-base-library",
+      "name": "@piwikpro/tracking-base-library",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
@@ -31,7 +31,7 @@
         "vite": "^5.1.7"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@piwikpro/tracking-base-library",
-  "private": true,
+  "version": "1.0.0",
+  "description": "Piwik PRO basic tracking library for the frontend.",
   "author": "Piwik Pro Integration Team <integrations@piwik.pro>",
   "license": "MIT",
-  "description": "Piwik PRO basic tracking library for the frontend.",
-  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PiwikPRO/tracking-base-library.git"
+  },
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",
@@ -16,7 +19,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Changes compared to other packages:

on-push:
- do not trigger workflow twice on pull requests

main:
- remove unused `workflow_dispatch`
- publish package in a single job so we don't have to upload artifacts between jobs and depend on each other
- don't use cache - we can fit within billable minute without it
- package.json as a single source of truth about version number - avoid situations like with https://github.com/PiwikPRO/ngx-piwik-pro/ where version in package.json and release version are out of sync
