### PR TITLE
1.1.2 Fix deleteCustomDimension argument type

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ Removes a custom dimension with the specified ID.
 
 | Name | Type |
 | :------ | :------ |
-| `customDimensionId` | `string` |
+| `customDimensionId` | `string` \| `number` |
 
 #### Returns
 
@@ -856,9 +856,9 @@ to a downloadable file creates a download event
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `trackAlsoMiddleAndRightClicks?` | `boolean` |
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `trackAlsoMiddleAndRightClicks` | `boolean` | `true` |
 
 #### Returns
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piwikpro/tracking-base-library",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Piwik PRO basic tracking library for the frontend.",
   "author": "Piwik Pro Integration Team <integrations@piwik.pro>",
   "license": "MIT",

--- a/src/services/custom-dimensions/customDimensions.service.ts
+++ b/src/services/custom-dimensions/customDimensions.service.ts
@@ -18,7 +18,7 @@ export function setCustomDimensionValue(
 /**
  * Removes a custom dimension with the specified ID.
  */
-export function deleteCustomDimension(customDimensionId: string) {
+export function deleteCustomDimension(customDimensionId: string | number) {
   push([
     CUSTOM_DIMENSIONS_TRACK_EVENT.DELETE_CUSTOM_DIMENSION,
     customDimensionId,

--- a/src/services/download-and-outlink/download-and-outlink.service.ts
+++ b/src/services/download-and-outlink/download-and-outlink.service.ts
@@ -27,7 +27,7 @@ export function trackLink(
  * an external site (different domain) creates an outlink event. Opening a link
  * to a downloadable file creates a download event
  */
-export function enableLinkTracking(trackAlsoMiddleAndRightClicks?: boolean) {
+export function enableLinkTracking(trackAlsoMiddleAndRightClicks = true) {
   push([
     DOWNLOAD_AND_OUTLINK_TRACK_EVENT.ENABLE_LINK_TRACKING,
     trackAlsoMiddleAndRightClicks,


### PR DESCRIPTION
`deleteCustomDimension` should take `number | string` as parameter as other functions in this service do